### PR TITLE
Support CUDA v10

### DIFF
--- a/src/ai/backend/accelerator/cuda/nvidia.py
+++ b/src/ai/backend/accelerator/cuda/nvidia.py
@@ -218,7 +218,7 @@ class libcudart:
             cls._lib = _load_libcudart()
             raw_ver = ctypes.c_int()
             cls.invoke_lib('cudaRuntimeGetVersion', ctypes.byref(raw_ver))
-            cls._version = (raw_ver // 1000, (raw_ver % 100) // 10)
+            cls._version = (raw_ver.value // 1000, (raw_ver.value % 100) // 10)
         if cls._lib is None:
             raise ImportError('CUDA runtime is not available!')
 

--- a/src/ai/backend/accelerator/cuda/nvidia.py
+++ b/src/ai/backend/accelerator/cuda/nvidia.py
@@ -18,6 +18,8 @@ class cudaDeviceProp_v10(ctypes.Structure):
     _fields_ = [
         ('name', ctypes.c_char * 256),
         ('uuid', ctypes.c_char * 16),  # cudaUUID_t
+        ('luid', ctypes.c_char * 8),
+        ('luidDeviceNodeMask', ctypes.c_uint),
         ('totalGlobalMem', ctypes.c_size_t),
         ('sharedMemPerBlock', ctypes.c_size_t),
         ('regsPerBlock', ctypes.c_int),

--- a/src/ai/backend/accelerator/cuda/nvidia.py
+++ b/src/ai/backend/accelerator/cuda/nvidia.py
@@ -252,12 +252,14 @@ class libcudart:
     @classmethod
     def get_device_props(cls, dev_idx: int):
         if cls._version >= (10, 0):
+            prop_type = cudaDeviceProp_v10
             props = cudaDeviceProp_v10()
         else:
+            prop_type = cudaDeviceProp
             props = cudaDeviceProp()
         cls.invoke_lib('cudaGetDeviceProperties', ctypes.byref(props), dev_idx)
         props = {
-            k: getattr(props, k) for k, _ in cudaDeviceProp._fields_
+            k: getattr(props, k) for k, _ in prop_type._fields_
         }
         pci_bus_id = b' ' * 16
         cls.invoke_lib('cudaDeviceGetPCIBusId',

--- a/src/ai/backend/accelerator/cuda/nvidia.py
+++ b/src/ai/backend/accelerator/cuda/nvidia.py
@@ -15,7 +15,7 @@ TARGET_CUDA_VERSIONS = (
 
 
 class cudaDeviceProp_v10(ctypes.Structure):
-    _fields = [
+    _fields_ = [
         ('name', ctypes.c_char * 256),
         ('uuid', ctypes.c_char * 16),  # cudaUUID_t
         ('totalGlobalMem', ctypes.c_size_t),


### PR DESCRIPTION
* CUDA v10 inserts an "uuid" field to cudaDeviceProperties struct,
  breaking our plugin's automatic GPU resource detection.